### PR TITLE
Nats tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tokio-nats"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sebastian Zimmer <sebastian.zim@googlemail.com>"]
-edition = "2018"
+edition = "2021"
 license = "LGPL-3.0"
 description = "Async-await ready NATS library"
 repository = "https://github.com/sebzim4500/tokio-nats"
@@ -18,6 +18,10 @@ subslice = "0.2.2"
 parking_lot = "0.12.1"
 derive_builder = "0.11.2"
 log = "0.4"
+tokio-rustls = "0.24"
+rustls-webpki = "0.100"
+rustls-pemfile = "1.0"
 
 [dev-dependencies]
 env_logger = "0.9.1"
+pretty_env_logger = "0.4"

--- a/examples/tls_client.rs
+++ b/examples/tls_client.rs
@@ -1,0 +1,44 @@
+use futures_util::StreamExt;
+use tokio_nats::{connect, NatsConfigBuilder};
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let mut args = std::env::args().skip(1);
+
+    if args.len() < 3 {
+        println!("Arguments: <ca cert location> <client cert location> <client key location> [NATS addr]");
+        std::process::exit(1);
+    }
+
+    let ca_location = args.next().expect("Expected CA cert location");
+    let cert_location = args.next().expect("Expected client cert location");
+    let key_location = args.next().expect("Expected client key location");
+    let nats_addr = args.next().unwrap_or_else(|| "127.0.0.1:4222".to_owned());
+
+    println!("Parameters given: Addr: {nats_addr}\n\tCA location: {ca_location}\n\tClient cert location: {cert_location}\n\tClient key location: {key_location}");
+
+    let config = NatsConfigBuilder::default()
+        .server(nats_addr)
+        .ca_cert(ca_location)
+        .client_cert(cert_location)
+        .client_key(key_location)
+        .build()
+        .unwrap();
+    let mut client = connect(config).await.unwrap();
+
+    client
+        .publish("MySubject", "hello world".as_bytes())
+        .await
+        .unwrap();
+
+    client
+        .subscribe("MyOtherSubject")
+        .await
+        .unwrap()
+        .for_each(|message| async move {
+            println!("Received message {:?}", message);
+        })
+        .await;
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -101,9 +101,23 @@ pub struct NatsConfig {
     /// Default 5 seconds.
     #[builder(default = "Duration::from_secs(5)")]
     connection_timeout: Duration,
-
+    /// CA certificate location in PEM format.
+    /// Mandatory to enable TLS connection
+    ///
+    /// Default: None
+    #[builder(default = "None")]
     ca_cert: Option<String>,
+    /// Client-side certificate location in PEM format.
+    /// Mandatory to enable TLS connection
+    ///
+    /// Default: None
+    #[builder(default = "None")]
     client_cert: Option<String>,
+    /// Client-side key location in PEM format.
+    /// Mandatory to enable TLS connection
+    ///
+    /// Default: None
+    #[builder(default = "None")]
     client_key: Option<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ use bytes::Bytes;
 pub use connection::{connect, NatsClient, NatsConfig, NatsConfigBuilder};
 pub use errors::Error;
 pub use subscriptions::NatsSubscription;
+pub use tls::{TLSConnBuild, TLSConnBuildError, TlsConnParams};
 
 /// A message that has been received by the NATS client.
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod connection;
 mod errors;
 mod protocol;
 mod subscriptions;
+mod tls;
 
 use bytes::Bytes;
 pub use connection::{connect, NatsClient, NatsConfig, NatsConfigBuilder};

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -16,8 +16,16 @@ pub(crate) enum ServerOp {
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub(crate) struct ServerInfo {
-    server_id: String,
-    version: String,
+    pub(crate) server_id: String,
+    pub(crate) version: String,
+    #[serde(default)]
+    pub(crate) auth_required: bool,
+    #[serde(default)]
+    pub(crate) tls_required: bool,
+    #[serde(default)]
+    pub(crate) tls_verify: bool,
+    #[serde(default)]
+    pub(crate) tls_available: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,41 +1,58 @@
-use std::{
-    fs::File,
-    io::{self, BufReader, Error},
-    path::Path,
-    sync::Arc,
-};
+use std::io::BufRead;
+use std::sync::Arc;
 
 use rustls_pemfile::{certs, read_one};
 use tokio::net::TcpStream;
-use tokio_rustls::TlsConnector;
-use tokio_rustls::{
-    client::TlsStream,
-    rustls::{Certificate, ClientConfig, OwnedTrustAnchor, PrivateKey, RootCertStore, ServerName},
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::{
+    Certificate, ClientConfig, OwnedTrustAnchor, PrivateKey, RootCertStore, ServerName,
 };
+use tokio_rustls::TlsConnector;
+use webpki::TrustAnchor;
 
-fn load_certs(path: &Path) -> io::Result<Vec<Certificate>> {
-    certs(&mut BufReader::new(File::open(path)?))
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid cert"))
-        .map(|mut certs| certs.drain(..).map(Certificate).collect())
+#[derive(Debug)]
+pub enum TLSConnBuildError {
+    NotConfigured,
+    UnableParseClientCertificate,
+    UnableParseClientKey,
+    UnableParseCaCertificate,
+    UnableToConnect(String),
 }
 
-fn load_key(path: &Path) -> PrivateKey {
-    log::debug!("Path: {path:?}");
-    let cert_file = File::open(path).expect("cannot open private key file");
-    let mut reader = BufReader::new(cert_file);
+#[derive(Debug, Clone)]
+pub struct TlsConnParams {
+    pub(crate) client_key: PrivateKey,
+    pub(crate) client_certs: Vec<Certificate>,
+    pub(crate) root_cert: RootCertStore,
+}
+
+#[derive(Debug)]
+pub struct TLSConnBuild {
+    client_key: Option<PrivateKey>,
+    client_certs: Vec<Certificate>,
+    root_cert: RootCertStore,
+}
+
+impl Default for TLSConnBuild {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn load_key(mut reader: &mut dyn BufRead) -> Result<PrivateKey, TLSConnBuildError> {
     loop {
-        match read_one(&mut reader).expect("cannot parse private key file") {
+        match read_one(&mut reader).map_err(|_| TLSConnBuildError::UnableParseClientKey)? {
             Some(rustls_pemfile::Item::ECKey(key)) => {
                 log::trace!("ECKey");
-                return PrivateKey(key);
+                return Ok(PrivateKey(key));
             }
             Some(rustls_pemfile::Item::RSAKey(key)) => {
                 log::trace!("RSAKey");
-                return PrivateKey(key);
+                return Ok(PrivateKey(key));
             }
             Some(rustls_pemfile::Item::PKCS8Key(key)) => {
                 log::trace!("PKCS8Key");
-                return PrivateKey(key);
+                return Ok(PrivateKey(key));
             }
             None => {
                 log::debug!("No type found");
@@ -44,48 +61,99 @@ fn load_key(path: &Path) -> PrivateKey {
             _ => {}
         }
     }
-    panic!("No keys found in {path:?}");
+    Err(TLSConnBuildError::UnableParseClientKey)
 }
 
-pub(crate) async fn tls_connection(
+impl TLSConnBuild {
+    pub fn new() -> TLSConnBuild {
+        TLSConnBuild {
+            client_key: None,
+            client_certs: Vec::new(),
+            root_cert: RootCertStore::empty(),
+        }
+    }
+
+    pub fn client_certs(&mut self, mut reader: &mut dyn BufRead) -> Result<(), TLSConnBuildError> {
+        self.client_certs = certs(&mut reader)
+            .map(|mut certs| certs.drain(..).map(Certificate).collect())
+            .map_err(|_| TLSConnBuildError::UnableParseClientCertificate)?;
+
+        Ok(())
+    }
+
+    pub fn client_key(&mut self, reader: &mut dyn BufRead) -> Result<(), TLSConnBuildError> {
+        self.client_key = Some(load_key(reader)?);
+        Ok(())
+    }
+
+    pub fn root_cert(&mut self, mut reader: &mut dyn BufRead) -> Result<(), TLSConnBuildError> {
+        let certs = certs(&mut reader).map_err(|_| TLSConnBuildError::UnableParseCaCertificate)?;
+
+        let trust_anchors: Result<Vec<OwnedTrustAnchor>, TLSConnBuildError> = certs
+            .iter()
+            .map(|cert| {
+                let ta: Result<TrustAnchor, TLSConnBuildError> =
+                    webpki::TrustAnchor::try_from_cert_der(cert)
+                        .map_err(|_| TLSConnBuildError::UnableParseCaCertificate);
+                let ta = ta?;
+                Ok(OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                ))
+            })
+            .collect();
+        let trust_anchors = trust_anchors?;
+        self.root_cert
+            .add_server_trust_anchors(trust_anchors.into_iter());
+        Ok(())
+    }
+
+    pub(crate) fn is_ready(&self) -> bool {
+        !self.root_cert.is_empty() && !self.client_certs.is_empty() && self.client_key.is_some()
+    }
+
+    pub fn build(self) -> Result<TlsConnParams, TLSConnBuildError> {
+        if !self.is_ready() {
+            return Err(TLSConnBuildError::NotConfigured);
+        }
+
+        if let (Some(client_key), client_certs, root_cert) =
+            (self.client_key, self.client_certs, self.root_cert)
+        {
+            Ok(TlsConnParams {
+                client_key,
+                client_certs,
+                root_cert,
+            })
+        } else {
+            Err(TLSConnBuildError::NotConfigured)
+        }
+    }
+}
+
+pub(crate) async fn connect(
     stream: TcpStream,
     domain: &str,
-    ca_location: &str,
-    cert_location: &str,
-    key_location: &str,
-) -> Result<TlsStream<TcpStream>, Error> {
-    let mut root_cert_store = RootCertStore::empty();
-    let mut pem = BufReader::new(File::open(ca_location)?);
+    tls_params: TlsConnParams,
+) -> Result<TlsStream<TcpStream>, TLSConnBuildError> {
+    let domain = ServerName::try_from(domain)
+        .map_err(|_| TLSConnBuildError::UnableToConnect("Invalid dns name".to_owned()))?;
 
-    let certs = rustls_pemfile::certs(&mut pem)?;
-    let trust_anchors = certs.iter().map(|cert| {
-        let ta = webpki::TrustAnchor::try_from_cert_der(&cert[..]).unwrap();
-        OwnedTrustAnchor::from_subject_spki_name_constraints(
-            ta.subject,
-            ta.spki,
-            ta.name_constraints,
-        )
-    });
-    root_cert_store.add_server_trust_anchors(trust_anchors);
+    log::trace!("Connecting TLS using domain: {domain:?}");
 
     let config_builder = ClientConfig::builder()
         .with_safe_defaults()
-        .with_root_certificates(root_cert_store);
+        .with_root_certificates(tls_params.root_cert);
 
-    let config = {
-        let certs = load_certs(Path::new(cert_location))?;
-        let key = load_key(Path::new(key_location));
-        config_builder
-            .with_single_cert(certs, key)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))
-            .unwrap()
-    };
+    let config = config_builder
+        .with_single_cert(tls_params.client_certs, tls_params.client_key)
+        .map_err(|_| TLSConnBuildError::UnableToConnect("Unable to TLS config".to_owned()))?;
 
-    let domain = ServerName::try_from(domain)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dns name"))?;
-
-    log::trace!("Connecting TLS using domain: {domain:?}");
     let connector = TlsConnector::from(Arc::new(config));
 
-    connector.connect(domain, stream).await
+    connector
+        .connect(domain, stream)
+        .await
+        .map_err(|e| TLSConnBuildError::UnableToConnect(e.to_string()))
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,91 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, Error},
+    path::Path,
+    sync::Arc,
+};
+
+use rustls_pemfile::{certs, read_one};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use tokio_rustls::{
+    client::TlsStream,
+    rustls::{Certificate, ClientConfig, OwnedTrustAnchor, PrivateKey, RootCertStore, ServerName},
+};
+
+fn load_certs(path: &Path) -> io::Result<Vec<Certificate>> {
+    certs(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid cert"))
+        .map(|mut certs| certs.drain(..).map(Certificate).collect())
+}
+
+fn load_key(path: &Path) -> PrivateKey {
+    log::debug!("Path: {path:?}");
+    let cert_file = File::open(path).expect("cannot open private key file");
+    let mut reader = BufReader::new(cert_file);
+    loop {
+        match read_one(&mut reader).expect("cannot parse private key file") {
+            Some(rustls_pemfile::Item::ECKey(key)) => {
+                log::trace!("ECKey");
+                return PrivateKey(key);
+            }
+            Some(rustls_pemfile::Item::RSAKey(key)) => {
+                log::trace!("RSAKey");
+                return PrivateKey(key);
+            }
+            Some(rustls_pemfile::Item::PKCS8Key(key)) => {
+                log::trace!("PKCS8Key");
+                return PrivateKey(key);
+            }
+            None => {
+                log::debug!("No type found");
+                break;
+            }
+            _ => {}
+        }
+    }
+    panic!("No keys found in {path:?}");
+}
+
+pub(crate) async fn tls_connection(
+    stream: TcpStream,
+    domain: &str,
+    ca_location: &str,
+    cert_location: &str,
+    key_location: &str,
+) -> Result<TlsStream<TcpStream>, Error> {
+    let mut root_cert_store = RootCertStore::empty();
+    let mut pem = BufReader::new(File::open(ca_location)?);
+
+    let certs = rustls_pemfile::certs(&mut pem)?;
+    let trust_anchors = certs.iter().map(|cert| {
+        let ta = webpki::TrustAnchor::try_from_cert_der(&cert[..]).unwrap();
+        OwnedTrustAnchor::from_subject_spki_name_constraints(
+            ta.subject,
+            ta.spki,
+            ta.name_constraints,
+        )
+    });
+    root_cert_store.add_server_trust_anchors(trust_anchors);
+
+    let config_builder = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_cert_store);
+
+    let config = {
+        let certs = load_certs(Path::new(cert_location))?;
+        let key = load_key(Path::new(key_location));
+        config_builder
+            .with_single_cert(certs, key)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))
+            .unwrap()
+    };
+
+    let domain = ServerName::try_from(domain)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dns name"))?;
+
+    log::trace!("Connecting TLS using domain: {domain:?}");
+    let connector = TlsConnector::from(Arc::new(config));
+
+    connector.connect(domain, stream).await
+}


### PR DESCRIPTION
## Add mechanism to handle NATS over TLS.

In order to handle that, NATS server MUST send `tls_verify` flag as `true` *and* client MUST supply:
* CA Certificate (PEM format)
* Client Certificate (PEM format)
* Client Key (PEM format)

